### PR TITLE
CUDA Graph follow up

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -457,6 +457,7 @@ class TrainBenchmarkRunner(BenchmarkRunner):
                 for _ in range(self.num_warm_iter):
                     _warmup()
             torch.cuda.current_stream().wait_stream(s)
+            torch.cuda.synchronize()
 
             g = torch.cuda.CUDAGraph()
             with torch.cuda.graph(g):


### PR DESCRIPTION
Synchronization does not do much functionally. However, the error massages are more informative in case of failure. 
Without `torch.cuda.synchronize()`:
```
$ TIMM_BENCHMARK_ENABLE_CUDAGRAPH=1 python -u /workspace/timm-models/pytorch-image-models/benchmark.py --bench train --model adv_inception_v3 --img-size 224 -b 128 --fuser nvfuser --aot-autograd
Benchmarking in float32 precision. NCHW layout. torchscript disabled
Model adv_inception_v3 created, param count: 23834568
Running train benchmark on adv_inception_v3 for 40 steps w/ input size (3, 224, 224) and batch size 128.
/opt/pytorch/pytorch/torch/jit/_check.py:181: UserWarning: The TorchScript type system doesn't support instance-level annotations on empty non-base types in `__init__`. Instead, either 1) use a type annotation in the class body, or 2) wrap the type in `torch.jit.Attribute`.
  warnings.warn("The TorchScript type system doesn't support "
ERROR: "CUDA error: operation failed due to a previous error during capture
CUDA kernel errors might be asynchronously reported at some other API call,so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1." while running benchmark.
Traceback (most recent call last):
  File "/workspace/timm-models/pytorch-image-models/benchmark.py", line 465, in run
    _step(sync=False)
  File "/workspace/timm-models/pytorch-image-models/benchmark.py", line 431, in _step
    self.loss(output, target).backward()
  File "/opt/pytorch/pytorch/torch/_tensor.py", line 482, in backward
    torch.autograd.backward(
  File "/opt/pytorch/pytorch/torch/autograd/__init__.py", line 197, in backward
    Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
  File "/opt/pytorch/pytorch/torch/autograd/function.py", line 267, in apply
    return user_fn(self, *args)
  File "/opt/pytorch/torchdynamo/torchdynamo/eval_frame.py", line 167, in _fn
    return fn(*args, **kwargs)
  File "/opt/pytorch/pytorch/functorch/_src/aot_autograd.py", line 435, in backward
    out = call_func_with_args(
  File "/opt/pytorch/pytorch/functorch/_src/aot_autograd.py", line 252, in call_func_with_args
    out = normalize_as_list(f(args))
  File "/opt/pytorch/pytorch/functorch/_src/aot_autograd.py", line 230, in g
    return f(*args)
  File "/opt/pytorch/pytorch/torch/nn/modules/module.py", line 1190, in _call_impl
    return forward_call(*input, **kwargs)
RuntimeError: The following operation failed in the TorchScript interpreter.
Traceback of TorchScript (most recent call last):
  File "<eval_with_key>.10", line 786, in forward
    getitem_681 = native_batch_norm_backward_65[1]
    getitem_682 = native_batch_norm_backward_65[2];  native_batch_norm_backward_65 = None
    convolution_backward_65 = torch.ops.aten.convolution_backward(getitem_680, relu_27, primals_85, [0], [1, 1], [1, 1], [1, 1], False, [0, 0], 1, [True, True, False]);  getitem_680 = primals_85 = None
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
    getitem_683 = convolution_backward_65[0]
    getitem_684 = convolution_backward_65[1];  convolution_backward_65 = None
RuntimeError: captures_underway == 0 INTERNAL ASSERT FAILED at "/opt/pytorch/pytorch/c10/cuda/CUDACachingAllocator.cpp":1531, please report a bug to PyTorch. 


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/workspace/timm-models/pytorch-image-models/benchmark.py", line 735, in <module>
    main()
  File "/workspace/timm-models/pytorch-image-models/benchmark.py", line 719, in main
    results = benchmark(args)
  File "/workspace/timm-models/pytorch-image-models/benchmark.py", line 648, in benchmark
    run_results = _try_run(
  File "/workspace/timm-models/pytorch-image-models/benchmark.py", line 595, in _try_run
    results = bench.run()
  File "/workspace/timm-models/pytorch-image-models/benchmark.py", line 465, in run
    _step(sync=False)
  File "/opt/pytorch/pytorch/torch/cuda/graphs.py", line 159, in __exit__
    self.cuda_graph.capture_end()
  File "/opt/pytorch/pytorch/torch/cuda/graphs.py", line 81, in capture_end
    super(CUDAGraph, self).capture_end()
RuntimeError: CUDA error: operation failed due to a previous error during capture
CUDA kernel errors might be asynchronously reported at some other API call,so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1.
```

With `torch.cuda.synchronize()`:
```
$ TIMM_BENCHMARK_ENABLE_CUDAGRAPH=1 python -u /workspace/timm-models/pytorch-image-models/benchmark.py --bench train --model adv_inception_v3 --img-size 224 -b 128 --fuser nvfuser --aot-autograd
Benchmarking in float32 precision. NCHW layout. torchscript disabled
Model adv_inception_v3 created, param count: 23834568
Running train benchmark on adv_inception_v3 for 40 steps w/ input size (3, 224, 224) and batch size 128.
/opt/pytorch/pytorch/torch/jit/_check.py:181: UserWarning: The TorchScript type system doesn't support instance-level annotations on empty non-base types in `__init__`. Instead, either 1) use a type annotation in the class body, or 2) wrap the type in `torch.jit.Attribute`.
  warnings.warn("The TorchScript type system doesn't support "
ERROR: "CUDA error: out of memory
CUDA kernel errors might be asynchronously reported at some other API call,so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1." while running benchmark.
Traceback (most recent call last):
  File "/workspace/timm-models/pytorch-image-models/benchmark.py", line 465, in run
    _step(sync=False)
  File "/workspace/timm-models/pytorch-image-models/benchmark.py", line 425, in _step
    output = self.model(self.example_inputs)
  File "/opt/pytorch/pytorch/torch/nn/modules/module.py", line 1190, in _call_impl
    return forward_call(*input, **kwargs)
  File "/opt/pytorch/pytorch/functorch/_src/aot_autograd.py", line 865, in forward
    return compiled_f(
  File "/opt/pytorch/pytorch/functorch/_src/aot_autograd.py", line 803, in returned_function
    out = cached_fn(flat_tensor_args)
  File "/opt/pytorch/pytorch/functorch/_src/aot_autograd.py", line 230, in g
    return f(*args)
  File "/opt/pytorch/pytorch/functorch/_src/aot_autograd.py", line 443, in compiled_function
    return CompiledFunction.apply(*remove_dupe_args(args))
  File "/opt/pytorch/torchdynamo/torchdynamo/eval_frame.py", line 167, in _fn
    return fn(*args, **kwargs)
  File "/opt/pytorch/pytorch/functorch/_src/aot_autograd.py", line 417, in forward
    fw_outs = call_func_with_args(
  File "/opt/pytorch/pytorch/functorch/_src/aot_autograd.py", line 252, in call_func_with_args
    out = normalize_as_list(f(args))
  File "/opt/pytorch/pytorch/functorch/_src/aot_autograd.py", line 230, in g
    return f(*args)
  File "/opt/pytorch/pytorch/torch/nn/modules/module.py", line 1190, in _call_impl
    return forward_call(*input, **kwargs)
RuntimeError: The following operation failed in the TorchScript interpreter.
Traceback of TorchScript (most recent call last):
RuntimeError: CUDA out of memory. Tried to allocate 14.00 MiB (GPU 0; 15.78 GiB total capacity; 11.89 GiB already allocated; 8.75 MiB free; 15.37 GiB reserved in total by PyTorch) If reserved memory is >> allocated memory try setting max_split_size_mb to avoid fragmentation.  See documentation for Memory Management and PYTORCH_CUDA_ALLOC_CONF


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/workspace/timm-models/pytorch-image-models/benchmark.py", line 735, in <module>
    main()
  File "/workspace/timm-models/pytorch-image-models/benchmark.py", line 719, in main
    results = benchmark(args)
  File "/workspace/timm-models/pytorch-image-models/benchmark.py", line 648, in benchmark
    run_results = _try_run(
  File "/workspace/timm-models/pytorch-image-models/benchmark.py", line 595, in _try_run
    results = bench.run()
  File "/workspace/timm-models/pytorch-image-models/benchmark.py", line 465, in run
    _step(sync=False)
  File "/opt/pytorch/pytorch/torch/cuda/graphs.py", line 159, in __exit__
    self.cuda_graph.capture_end()
  File "/opt/pytorch/pytorch/torch/cuda/graphs.py", line 81, in capture_end
    super(CUDAGraph, self).capture_end()
RuntimeError: CUDA error: out of memory
CUDA kernel errors might be asynchronously reported at some other API call,so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1.
```

In the second case the error message correctly pointed out that device run out of memory, while in the first example the message  mentions `CUDACachingAllocator` that loosely informs abut memory issue and may be interpreted incorrectly.